### PR TITLE
BS_154_Env_password, switch to env variable

### DIFF
--- a/src/main/java/org/bcit/comp2522/project/DatabaseHandler.java
+++ b/src/main/java/org/bcit/comp2522/project/DatabaseHandler.java
@@ -33,7 +33,7 @@ public class DatabaseHandler {
 
 
     public DatabaseHandler(String collection){
-        String password = "SuperSecretPassword";//hopefully nobody is able to find the supersecretpassoword
+        String password = "${MONGO_KEY}";//hopefully nobody is able to find the supersecretpassoword
         ConnectionString connectionString = new ConnectionString(
                 "mongodb+srv://Noooooooor:" + password + "@2522.yczfyxd.mongodb.net/?retryWrites=true&w=majority");
         MongoClientSettings settings = MongoClientSettings.builder()


### PR DESCRIPTION
Switched mongo password into env variable for security reasons, so client will need to have this configured to run mongo connection